### PR TITLE
Mdickson dotnetstandard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 *.dll
 *.log
 
+packages/
+
 # Ignore .user and .suo files as these are user preference specific
 # http://stackoverflow.com/questions/72298/should-i-add-the-visual-studio-suo-and-user-files-to-source-control
 *.suo

--- a/addon-modules/Gloebit/prebuild-gloebit.xml
+++ b/addon-modules/Gloebit/prebuild-gloebit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<Project frameworkVersion="v4_6" name="Gloebit" path="addon-modules/Gloebit/GloebitMoneyModule" type="Library">
+<Project frameworkVersion="v4_6_1" name="Gloebit" path="addon-modules/Gloebit/GloebitMoneyModule" type="Library">
   <Configuration name="Debug">
     <Options>
       <OutputPath>../../../bin/</OutputPath>

--- a/addon-modules/jOpenSim.Profile/prebuild-jopensimprofile.xml
+++ b/addon-modules/jOpenSim.Profile/prebuild-jopensimprofile.xml
@@ -1,4 +1,4 @@
-<Project frameworkVersion="v4_6" name="jOpenSim.Profile" path="addon-modules/jOpenSim.Profile/jOpenSimProfile" type="Library">
+<Project frameworkVersion="v4_6_1" name="jOpenSim.Profile" path="addon-modules/jOpenSim.Profile/jOpenSimProfile" type="Library">
   <Configuration name="Debug">
     <Options>
       <OutputPath>../../../bin</OutputPath>

--- a/addon-modules/jOpenSim.Search/prebuild-jopensimsearch.xml
+++ b/addon-modules/jOpenSim.Search/prebuild-jopensimsearch.xml
@@ -1,4 +1,4 @@
-<Project frameworkVersion="v4_6" name="jOpenSim.Search" path="addon-modules/jOpenSim.Search/jOpenSimSearch" type="Library">
+<Project frameworkVersion="v4_6_1" name="jOpenSim.Search" path="addon-modules/jOpenSim.Search/jOpenSimSearch" type="Library">
   <Configuration name="Debug">
     <Options>
       <OutputPath>../../../bin</OutputPath>

--- a/bin/Gloebit.ini.example
+++ b/bin/Gloebit.ini.example
@@ -3,7 +3,7 @@
 
     ;# {Enabled} {[Startup]economymodule:Gloebit} {Enable Gloebit Money Module Globally?} {false, true} false
     ;; Set to true to enable GMM for all regions controlled by this OpenSim process.
-    ;; Requires that "economymodule = Gloebit" is set in opensim.ini
+    ;; Requires that "economymodule = Gloebit" is set in [Economy] or [Startup] section of opensim.ini
     ;; If set to false, can be enabled for individual regions - see GLBEnabledOnlyInRegions below
     Enabled = false
 
@@ -51,6 +51,14 @@
 
     ;; GLBOwnerEmail should be replaced with the email address (or other contact mechanism) for the person who manages this OpenSim process.
     ; GLBOwnerEmail = Manager@example.com
+
+    ;;;;; CONFIGURE NEW SESSION MESSAGING ;;;;;
+    ;; The following determine if a user receives messaging at the start of a new session
+    ;; A new session is defined as the first time a user enters a Gloebit enabled region for a Gloebit app during a viewer login
+    ;# {GLBShowNewSessionPurchaseIM} {Show purchase gloebits IM to user at session start?} {false, true} false
+    ; GLBShowNewSessionPurchaseIM = false
+    ;# {GLBShowNewSessionAuthIM} {Show auth app IM to user at session start?} {false, true} true
+    ; GLBShowNewSessionAuthIM = true
 
     ;;;;; CONFIGURE SINGLE GLOEBIT DB FOR APP OR GRID ;;;;;;
     ;; Optional - If not configured here, Gloebit will use the DataService 

--- a/prebuild.xml
+++ b/prebuild.xml
@@ -36,7 +36,7 @@
  
     <!-- Core OpenSim Projects -->
 <!--
-        <Project frameworkVersion="v4_6" name="OpenSim.Model" path="OpenSim/Model" type="Library">
+        <Project frameworkVersion="v4_6_1" name="OpenSim.Model" path="OpenSim/Model" type="Library">
           <Configuration name="Debug">
             <Options>
               <OutputPath>../../../bin/</OutputPath>
@@ -57,7 +57,7 @@
         </Project>
 -->
 
-    <Project frameworkVersion="v4_6" name="SmartThreadPool" path="ThirdParty/SmartThreadPool" type="Library">
+    <Project frameworkVersion="v4_6_1" name="SmartThreadPool" path="ThirdParty/SmartThreadPool" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../bin/</OutputPath>
@@ -81,7 +81,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Framework" path="OpenSim/Framework" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Framework" path="OpenSim/Framework" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../bin/</OutputPath>
@@ -125,7 +125,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.Interfaces" path="OpenSim/Services/Interfaces" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.Interfaces" path="OpenSim/Services/Interfaces" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -157,7 +157,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Framework.Monitoring" path="OpenSim/Framework/Monitoring" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Framework.Monitoring" path="OpenSim/Framework/Monitoring" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -186,7 +186,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Framework.Servers.HttpServer" path="OpenSim/Framework/Servers/HttpServer" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Framework.Servers.HttpServer" path="OpenSim/Framework/Servers/HttpServer" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -227,7 +227,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Framework.Console" path="OpenSim/Framework/Console" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Framework.Console" path="OpenSim/Framework/Console" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -256,7 +256,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Framework.Serialization" path="OpenSim/Framework/Serialization" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Framework.Serialization" path="OpenSim/Framework/Serialization" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -286,7 +286,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Data" path="OpenSim/Data" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Data" path="OpenSim/Data" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../bin/</OutputPath>
@@ -317,7 +317,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Framework.AssetLoader.Filesystem" path="OpenSim/Framework/AssetLoader/Filesystem" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Framework.AssetLoader.Filesystem" path="OpenSim/Framework/AssetLoader/Filesystem" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -344,7 +344,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Framework.Servers" path="OpenSim/Framework/Servers" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Framework.Servers" path="OpenSim/Framework/Servers" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -377,7 +377,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Capabilities" path="OpenSim/Capabilities" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Capabilities" path="OpenSim/Capabilities" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../bin/</OutputPath>
@@ -413,7 +413,7 @@
     </Project>
 
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.PhysicsModules.SharedBase" path="OpenSim/Region/PhysicsModules/SharedBase" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.PhysicsModules.SharedBase" path="OpenSim/Region/PhysicsModules/SharedBase" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -440,7 +440,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.Framework" path="OpenSim/Region/Framework" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.Framework" path="OpenSim/Region/Framework" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -490,7 +490,7 @@
     <!-- OGS projects -->
 
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Server.Base" path="OpenSim/Server/Base" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Server.Base" path="OpenSim/Server/Base" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -527,7 +527,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.Base" path="OpenSim/Services/Base" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.Base" path="OpenSim/Services/Base" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -556,40 +556,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.UserAccountService" path="OpenSim/Services/UserAccountService" type="Library">
-      <Configuration name="Debug">
-        <Options>
-          <OutputPath>../../../bin/</OutputPath>
-        </Options>
-      </Configuration>
-      <Configuration name="Release">
-        <Options>
-          <OutputPath>../../../bin/</OutputPath>
-        </Options>
-      </Configuration>
-
-      <ReferencePath>../../../bin/</ReferencePath>
-      <Reference name="System"/>
-      <Reference name="System.Web"/>
-      <Reference name="OpenMetaverseTypes" path="../../../bin/"/>
-      <Reference name="OpenMetaverse" path="../../../bin/"/>
-      <Reference name="OpenSim.Framework"/>
-      <Reference name="OpenSim.Framework.Console"/>
-      <Reference name="OpenSim.Framework.Servers.HttpServer"/>
-      <Reference name="OpenSim.Services.Interfaces"/>
-      <Reference name="OpenSim.Services.Base"/>
-      <Reference name="OpenSim.Data"/>
-      <Reference name="Nini" path="../../../bin/"/>
-      <Reference name="log4net" path="../../../bin/"/>
-
-      <Files>
-        <Match pattern="*.cs" recurse="true">
-         <Exclude name="obj" pattern="obj"/>
-        </Match>
-      </Files>
-    </Project>
-
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.FriendsService" path="OpenSim/Services/Friends" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.UserAccountService" path="OpenSim/Services/UserAccountService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -622,7 +589,40 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.Connectors" path="OpenSim/Services/Connectors" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.FriendsService" path="OpenSim/Services/Friends" type="Library">
+      <Configuration name="Debug">
+        <Options>
+          <OutputPath>../../../bin/</OutputPath>
+        </Options>
+      </Configuration>
+      <Configuration name="Release">
+        <Options>
+          <OutputPath>../../../bin/</OutputPath>
+        </Options>
+      </Configuration>
+
+      <ReferencePath>../../../bin/</ReferencePath>
+      <Reference name="System"/>
+      <Reference name="System.Web"/>
+      <Reference name="OpenMetaverseTypes" path="../../../bin/"/>
+      <Reference name="OpenMetaverse" path="../../../bin/"/>
+      <Reference name="OpenSim.Framework"/>
+      <Reference name="OpenSim.Framework.Console"/>
+      <Reference name="OpenSim.Framework.Servers.HttpServer"/>
+      <Reference name="OpenSim.Services.Interfaces"/>
+      <Reference name="OpenSim.Services.Base"/>
+      <Reference name="OpenSim.Data"/>
+      <Reference name="Nini" path="../../../bin/"/>
+      <Reference name="log4net" path="../../../bin/"/>
+
+      <Files>
+        <Match pattern="*.cs" recurse="true">
+         <Exclude name="obj" pattern="obj"/>
+        </Match>
+      </Files>
+    </Project>
+
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.Connectors" path="OpenSim/Services/Connectors" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -665,7 +665,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.SimulationService" path="OpenSim/Services/SimulationService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.SimulationService" path="OpenSim/Services/SimulationService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -701,7 +701,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.AssetService" path="OpenSim/Services/AssetService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.AssetService" path="OpenSim/Services/AssetService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -735,7 +735,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.FSAssetService" path="OpenSim/Services/FSAssetService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.FSAssetService" path="OpenSim/Services/FSAssetService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -771,7 +771,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.AuthorizationService" path="OpenSim/Services/AuthorizationService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.AuthorizationService" path="OpenSim/Services/AuthorizationService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -804,7 +804,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.FreeswitchService" path="OpenSim/Services/FreeswitchService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.FreeswitchService" path="OpenSim/Services/FreeswitchService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -838,7 +838,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.AuthenticationService" path="OpenSim/Services/AuthenticationService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.AuthenticationService" path="OpenSim/Services/AuthenticationService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -873,7 +873,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.GridService" path="OpenSim/Services/GridService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.GridService" path="OpenSim/Services/GridService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -909,7 +909,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.EstateService" path="OpenSim/Services/EstateService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.EstateService" path="OpenSim/Services/EstateService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -940,7 +940,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.PresenceService" path="OpenSim/Services/PresenceService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.PresenceService" path="OpenSim/Services/PresenceService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -973,7 +973,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.AvatarService" path="OpenSim/Services/AvatarService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.AvatarService" path="OpenSim/Services/AvatarService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1006,7 +1006,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.InventoryService" path="OpenSim/Services/InventoryService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.InventoryService" path="OpenSim/Services/InventoryService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1042,7 +1042,7 @@
     </Project>
 
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.LLLoginService" path="OpenSim/Services/LLLoginService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.LLLoginService" path="OpenSim/Services/LLLoginService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1077,7 +1077,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.HypergridService" path="OpenSim/Services/HypergridService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.HypergridService" path="OpenSim/Services/HypergridService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1118,7 +1118,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.MapImageService" path="OpenSim/Services/MapImageService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.MapImageService" path="OpenSim/Services/MapImageService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1150,7 +1150,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.MuteListService" path="OpenSim/Services/MuteListService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.MuteListService" path="OpenSim/Services/MuteListService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1180,7 +1180,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.UserProfilesService" path="OpenSim/Services/UserProfilesService" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.UserProfilesService" path="OpenSim/Services/UserProfilesService" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1217,7 +1217,7 @@
       </Files>
     </Project>
  
-    <Project frameworkVersion="v4_6" name="OpenSim.Server.Handlers" path="OpenSim/Server/Handlers" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Server.Handlers" path="OpenSim/Server/Handlers" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1258,7 +1258,7 @@
     </Project>
 
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Capabilities.Handlers" path="OpenSim/Capabilities/Handlers" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Capabilities.Handlers" path="OpenSim/Capabilities/Handlers" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1300,7 +1300,7 @@
     </Project>
 
 
-    <Project frameworkVersion="v4_6" name="Robust" path="OpenSim/Server" type="Exe">
+    <Project frameworkVersion="v4_6_1" name="Robust" path="OpenSim/Server" type="Exe">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../bin/</OutputPath>
@@ -1337,7 +1337,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.ConsoleClient" path="OpenSim/ConsoleClient" type="Exe">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.ConsoleClient" path="OpenSim/ConsoleClient" type="Exe">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../bin/</OutputPath>
@@ -1372,7 +1372,7 @@
     </Project>
 
     <!-- ClientStack Plugins -->
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.ClientStack.LindenUDP" path="OpenSim/Region/ClientStack/Linden/UDP" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.ClientStack.LindenUDP" path="OpenSim/Region/ClientStack/Linden/UDP" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../../bin/</OutputPath>
@@ -1416,7 +1416,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.ClientStack.LindenCaps" path="OpenSim/Region/ClientStack/Linden/Caps" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.ClientStack.LindenCaps" path="OpenSim/Region/ClientStack/Linden/Caps" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../../bin/</OutputPath>
@@ -1463,7 +1463,7 @@
 
 	
     <!-- Data Base Modules -->
-    <Project frameworkVersion="v4_6" name="OpenSim.Data.MySQL" path="OpenSim/Data/MySQL" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Data.MySQL" path="OpenSim/Data/MySQL" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1503,7 +1503,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Data.PGSQL" path="OpenSim/Data/PGSQL" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Data.PGSQL" path="OpenSim/Data/PGSQL" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1541,7 +1541,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Data.SQLite" path="OpenSim/Data/SQLite" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Data.SQLite" path="OpenSim/Data/SQLite" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1582,7 +1582,7 @@
     </Project>
 	
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.CoreModules" path="OpenSim/Region/CoreModules" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.CoreModules" path="OpenSim/Region/CoreModules" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1651,7 +1651,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.OptionalModules" path="OpenSim/Region/OptionalModules" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.OptionalModules" path="OpenSim/Region/OptionalModules" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1711,7 +1711,7 @@
     </Project>
 
     <!-- Datastore Plugins -->
-    <Project frameworkVersion="v4_6" name="OpenSim.Data.Null" path="OpenSim/Data/Null" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Data.Null" path="OpenSim/Data/Null" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -1741,7 +1741,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.PhysicsModules.ConvexDecompositionDotNet" path="OpenSim/Region/PhysicsModules/ConvexDecompositionDotNet" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.PhysicsModules.ConvexDecompositionDotNet" path="OpenSim/Region/PhysicsModules/ConvexDecompositionDotNet" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -1769,7 +1769,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.PhysicsModule.Meshing" path="OpenSim/Region/PhysicsModules/Meshing" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.PhysicsModule.Meshing" path="OpenSim/Region/PhysicsModules/Meshing" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -1804,7 +1804,7 @@
     </Project>
 
     <!-- Physics Plug-ins -->
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.PhysicsModule.BasicPhysics" path="OpenSim/Region/PhysicsModules/BasicPhysics" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.PhysicsModule.BasicPhysics" path="OpenSim/Region/PhysicsModules/BasicPhysics" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -1831,7 +1831,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.PhysicsModule.POS" path="OpenSim/Region/PhysicsModules/POS" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.PhysicsModule.POS" path="OpenSim/Region/PhysicsModules/POS" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -1858,7 +1858,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.PhysicsModule.Ode" path="OpenSim/Region/PhysicsModules/Ode" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.PhysicsModule.Ode" path="OpenSim/Region/PhysicsModules/Ode" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -1890,7 +1890,7 @@
       </Files>
     </Project>
 
-   <Project frameworkVersion="v4_6" name="OpenSim.Region.PhysicsModule.ubOde" path="OpenSim/Region/PhysicsModules/ubOde" type="Library">
+   <Project frameworkVersion="v4_6_1" name="OpenSim.Region.PhysicsModule.ubOde" path="OpenSim/Region/PhysicsModules/ubOde" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -1924,7 +1924,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.PhysicsModule.ubOdeMeshing" path="OpenSim/Region/PhysicsModules/ubOdeMeshing" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.PhysicsModule.ubOdeMeshing" path="OpenSim/Region/PhysicsModules/ubOdeMeshing" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -1959,7 +1959,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.PhysicsModule.BulletS" path="OpenSim/Region/PhysicsModules/BulletS" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.PhysicsModule.BulletS" path="OpenSim/Region/PhysicsModules/BulletS" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -1999,7 +1999,7 @@
     </Project>
 
     <!-- OpenSim app -->
-    <Project frameworkVersion="v4_6" name="OpenSim" path="OpenSim/Region/Application" type="Exe">
+    <Project frameworkVersion="v4_6_1" name="OpenSim" path="OpenSim/Region/Application" type="Exe">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2044,7 +2044,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.ApplicationPlugins.LoadRegions" path="OpenSim/ApplicationPlugins/LoadRegions" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.ApplicationPlugins.LoadRegions" path="OpenSim/ApplicationPlugins/LoadRegions" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2079,7 +2079,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.ApplicationPlugins.RegionModulesController" path="OpenSim/ApplicationPlugins/RegionModulesController" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.ApplicationPlugins.RegionModulesController" path="OpenSim/ApplicationPlugins/RegionModulesController" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2110,7 +2110,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.ApplicationPlugins.RemoteController" path="OpenSim/ApplicationPlugins/RemoteController" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.ApplicationPlugins.RemoteController" path="OpenSim/ApplicationPlugins/RemoteController" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2152,7 +2152,7 @@
 
     <!-- Scene Server API Example Apps -->
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.ScriptEngine.Shared" path="OpenSim/Region/ScriptEngine/Shared" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.ScriptEngine.Shared" path="OpenSim/Region/ScriptEngine/Shared" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -2188,7 +2188,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.ScriptEngine.Shared.Api.Runtime" path="OpenSim/Region/ScriptEngine/Shared/Api/Runtime" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.ScriptEngine.Shared.Api.Runtime" path="OpenSim/Region/ScriptEngine/Shared/Api/Runtime" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../../../bin/</OutputPath>
@@ -2222,7 +2222,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.ScriptEngine.Shared.Api" path="OpenSim/Region/ScriptEngine/Shared/Api/Implementation" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.ScriptEngine.Shared.Api" path="OpenSim/Region/ScriptEngine/Shared/Api/Implementation" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../../../bin/</OutputPath>
@@ -2265,7 +2265,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.ScriptEngine.Shared.CodeTools" path="OpenSim/Region/ScriptEngine/Shared/CodeTools" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.ScriptEngine.Shared.CodeTools" path="OpenSim/Region/ScriptEngine/Shared/CodeTools" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../../bin/</OutputPath>
@@ -2296,7 +2296,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.ScriptEngine.Shared.Instance" path="OpenSim/Region/ScriptEngine/Shared/Instance" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.ScriptEngine.Shared.Instance" path="OpenSim/Region/ScriptEngine/Shared/Instance" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../../bin/</OutputPath>
@@ -2335,7 +2335,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.ScriptEngine.XEngine.Api.Runtime" path="OpenSim/Region/ScriptEngine/XEngine/Api/Runtime" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.ScriptEngine.XEngine.Api.Runtime" path="OpenSim/Region/ScriptEngine/XEngine/Api/Runtime" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../../../bin/</OutputPath>
@@ -2370,7 +2370,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.ScriptEngine.XEngine" path="OpenSim/Region/ScriptEngine/XEngine" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.ScriptEngine.XEngine" path="OpenSim/Region/ScriptEngine/XEngine" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -2417,7 +2417,7 @@
     </Project>
 
     <!-- YEngine/core XMRengine -->   
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.ScriptEngine.YEngine" path="OpenSim/Region/ScriptEngine/YEngine" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.ScriptEngine.YEngine" path="OpenSim/Region/ScriptEngine/YEngine" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -2463,7 +2463,7 @@
     
     <!-- Addons -->
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Addons.OfflineIM" path="OpenSim/Addons/OfflineIM" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Addons.OfflineIM" path="OpenSim/Addons/OfflineIM" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2511,7 +2511,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Addons.Groups" path="OpenSim/Addons/Groups" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Addons.Groups" path="OpenSim/Addons/Groups" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2564,7 +2564,7 @@
 
     <!-- Tools -->
 
-    <Project frameworkVersion="v4_6" name="pCampBot" path="OpenSim/Tools/pCampBot" type="Exe">
+    <Project frameworkVersion="v4_6_1" name="pCampBot" path="OpenSim/Tools/pCampBot" type="Exe">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2594,7 +2594,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Tools.lslc" path="OpenSim/Tools/Compiler" type="Exe">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Tools.lslc" path="OpenSim/Tools/Compiler" type="Exe">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2623,7 +2623,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Tools.Configger" path="OpenSim/Tools/Configger" type="Exe">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Tools.Configger" path="OpenSim/Tools/Configger" type="Exe">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2650,7 +2650,7 @@
     </Project>
 
     <!-- Test Clients -->
-    <Project frameworkVersion="v4_6" name="OpenSim.Tests.Clients.AssetClient" path="OpenSim/Tests/Clients/Assets" type="Exe">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Tests.Clients.AssetClient" path="OpenSim/Tests/Clients/Assets" type="Exe">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -2680,7 +2680,7 @@
     </Project>
 
     <!-- Test assemblies -->
-    <Project frameworkVersion="v4_6" name="OpenSim.Tests.Common" path="OpenSim/Tests/Common" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Tests.Common" path="OpenSim/Tests/Common" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2731,7 +2731,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Tests" path="OpenSim/Tests" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Tests" path="OpenSim/Tests" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../bin/</OutputPath>
@@ -2754,7 +2754,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Services.InventoryService.Tests" path="OpenSim/Services/InventoryService/Tests" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Services.InventoryService.Tests" path="OpenSim/Services/InventoryService/Tests" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -2797,7 +2797,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="Robust.Tests" path="OpenSim/Tests/Robust" type="Library">
+    <Project frameworkVersion="v4_6_1" name="Robust.Tests" path="OpenSim/Tests/Robust" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2835,7 +2835,7 @@
     </Project>
 
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Capabilities.Handlers.Tests" path="OpenSim/Capabilities/Handlers" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Capabilities.Handlers.Tests" path="OpenSim/Capabilities/Handlers" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2890,7 +2890,7 @@
     </Project>
 
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Data.Tests" path="OpenSim/Data/Tests" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Data.Tests" path="OpenSim/Data/Tests" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2933,7 +2933,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Framework.Tests" path="OpenSim/Framework/Tests" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Framework.Tests" path="OpenSim/Framework/Tests" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -2964,7 +2964,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Framework.Serialization.Tests" path="OpenSim/Framework/Serialization/Tests" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Framework.Serialization.Tests" path="OpenSim/Framework/Serialization/Tests" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -2996,7 +2996,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Framework.Servers.Tests" path="OpenSim/Framework/Servers/Tests" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Framework.Servers.Tests" path="OpenSim/Framework/Servers/Tests" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../bin/</OutputPath>
@@ -3027,7 +3027,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.CoreModules.Tests" path="OpenSim/Region/CoreModules" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.CoreModules.Tests" path="OpenSim/Region/CoreModules" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -3144,7 +3144,7 @@
     </Project>
 
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.Framework.Tests" path="OpenSim/Region/Framework" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.Framework.Tests" path="OpenSim/Region/Framework" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -3206,7 +3206,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.ClientStack.LindenCaps.Tests" path="OpenSim/Region/ClientStack/Linden/Caps" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.ClientStack.LindenCaps.Tests" path="OpenSim/Region/ClientStack/Linden/Caps" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../../bin/</OutputPath>
@@ -3247,7 +3247,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.ClientStack.LindenUDP.Tests" path="OpenSim/Region/ClientStack/Linden/UDP/Tests" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.ClientStack.LindenUDP.Tests" path="OpenSim/Region/ClientStack/Linden/UDP/Tests" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../../../bin/</OutputPath>
@@ -3281,7 +3281,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.ScriptEngine.Tests" path="OpenSim/Region/ScriptEngine" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.ScriptEngine.Tests" path="OpenSim/Region/ScriptEngine" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -3347,7 +3347,7 @@
            TODO: this is kind of lame, we basically build a duplicate
            assembly but with tests added in, just because we can't resolve cross-bin-dir-refs.
       -->
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.PhysicsModule.Ode.Tests" path="OpenSim/Region/PhysicsModules/Ode/Tests" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.PhysicsModule.Ode.Tests" path="OpenSim/Region/PhysicsModules/Ode/Tests" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../../bin/</OutputPath>
@@ -3380,7 +3380,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Region.PhysicsModule.BulletS.Tests" path="OpenSim/Region/PhysicsModules/BulletS/Tests" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Region.PhysicsModule.BulletS.Tests" path="OpenSim/Region/PhysicsModules/BulletS/Tests" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../../../bin/</OutputPath>
@@ -3414,7 +3414,7 @@
     </Project>
 
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Server.Handlers.Tests" path="OpenSim/Server/Handlers" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Server.Handlers.Tests" path="OpenSim/Server/Handlers" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -3462,7 +3462,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Tests.Stress" path="OpenSim/Tests/Stress" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Tests.Stress" path="OpenSim/Tests/Stress" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -3502,7 +3502,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Tests.Performance" path="OpenSim/Tests/Performance" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Tests.Performance" path="OpenSim/Tests/Performance" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>
@@ -3541,7 +3541,7 @@
       </Files>
     </Project>
 
-    <Project frameworkVersion="v4_6" name="OpenSim.Tests.Permissions" path="OpenSim/Tests/Permissions" type="Library">
+    <Project frameworkVersion="v4_6_1" name="OpenSim.Tests.Permissions" path="OpenSim/Tests/Permissions" type="Library">
       <Configuration name="Debug">
         <Options>
           <OutputPath>../../../bin/</OutputPath>


### PR DESCRIPTION
Convert to 4.6.1/dotnet standard 2.0. Some work started to move away from prebuild.  I'll probably teach it to generate an msbuild compatible new project structure and then drop it for good. 
